### PR TITLE
Display current spectators count on game page

### DIFF
--- a/api/app/controllers/games_controller.rb
+++ b/api/app/controllers/games_controller.rb
@@ -7,5 +7,7 @@ class GamesController < ApplicationController
     authorize! { true }
 
     @game = Game.create_or_find_by(identifier: params[:id])
+
+    current_human&.record_heartbeat(@game)
   end
 end

--- a/api/app/models/game.rb
+++ b/api/app/models/game.rb
@@ -1,4 +1,15 @@
 # frozen_string_literal: true
 
+# A game represents a particular gathering of humans to play bluff
 class Game < ApplicationRecord
+  has_many :attendances, class_name: 'GameAttendance'
+  has_many :humans, through: :attendances
+
+  before_create -> { self.last_action_at = Time.zone.now }
+
+  def recent_spectators_count
+    humans
+      .where("game_attendances.heartbeat_at > now() - interval '10 minutes'")
+      .count
+  end
 end

--- a/api/app/models/game_attendance.rb
+++ b/api/app/models/game_attendance.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# This records that a human attended a game, either as a player or a spectator.
+# This is a join table.
+class GameAttendance < ApplicationRecord
+  belongs_to :human
+  belongs_to :game
+
+  before_create -> { self.heartbeat_at = Time.zone.now }
+
+  # Record that the human is still at the game
+  def heartbeat!
+    touch(:heartbeat_at)
+  end
+end

--- a/api/app/models/human.rb
+++ b/api/app/models/human.rb
@@ -18,4 +18,16 @@ class Human < ApplicationRecord
       [Faker::Hipster.word, Faker::Creature::Animal.name].join(' ').titlecase
     end
   end
+
+  def record_heartbeat(game)
+    if (attendance = game.attendances.find_by_human_id(id)).present?
+      attendance.heartbeat!
+    else
+      game.attendances.create!(human_id: id)
+    end
+  end
+
+  def heartbeat_for(game)
+    game.attendances.find_by_human_id!(id).heartbeat_at
+  end
 end

--- a/api/app/views/games/show.json.jbuilder
+++ b/api/app/views/games/show.json.jbuilder
@@ -2,14 +2,15 @@
 
 json.data do
   json.id @game.identifier
-  json.players_count 4
-  json.spectators_count 5
+  json.last_action_at @game.last_action_at.to_i * 1000
+  json.spectators_count @game.recent_spectators_count
 end
 
 json.meta do
   if current_human.present?
     json.human do
       json.nickname current_human.nickname
+      json.heartbeat_at current_human.heartbeat_for(@game).to_i * 1000
     end
   end
 end

--- a/api/db/migrate/20200424043535_add_game_attendance.rb
+++ b/api/db/migrate/20200424043535_add_game_attendance.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Track who has attended which games. Some will be players, and others
+# spectators.
+class AddGameAttendance < ActiveRecord::Migration[6.0]
+  def change
+    create_table :game_attendances do |t|
+      t.references :human, null: false, foreign_key: true
+      t.references :game, null: false, foreign_key: true
+      t.timestamp :heartbeat_at, null: false
+
+      t.timestamps
+    end
+
+    add_index :game_attendances, %i[human_id game_id], unique: true
+  end
+end

--- a/api/db/migrate/20200424052330_add_last_action_at_to_game.rb
+++ b/api/db/migrate/20200424052330_add_last_action_at_to_game.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# We'll track when a game last had an activity (e.g. a bet), which will help us
+# come up with a smart polling strategy on the front-end: when people are
+# actively playing, we'll poll for updates more frequently.
+class AddLastActionAtToGame < ActiveRecord::Migration[6.0]
+  def up
+    add_column :games, :last_action_at, :timestamp, null: true
+
+    execute 'update games set last_action_at = created_at'
+
+    change_column_null :games, :last_action_at, false
+  end
+
+  def down
+    remove_column :games, :last_action_at
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,15 +10,27 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_24_025346) do
+ActiveRecord::Schema.define(version: 2020_04_24_052330) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "game_attendances", force: :cascade do |t|
+    t.bigint "human_id", null: false
+    t.bigint "game_id", null: false
+    t.datetime "heartbeat_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["game_id"], name: "index_game_attendances_on_game_id"
+    t.index ["human_id", "game_id"], name: "index_game_attendances_on_human_id_and_game_id", unique: true
+    t.index ["human_id"], name: "index_game_attendances_on_human_id"
+  end
 
   create_table "games", force: :cascade do |t|
     t.string "identifier", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "last_action_at", null: false
     t.index ["identifier"], name: "index_games_on_identifier", unique: true
   end
 
@@ -30,4 +42,6 @@ ActiveRecord::Schema.define(version: 2020_04_24_025346) do
     t.index ["uuid"], name: "index_humans_on_uuid", unique: true
   end
 
+  add_foreign_key "game_attendances", "games"
+  add_foreign_key "game_attendances", "humans"
 end

--- a/web/elm.json
+++ b/web/elm.json
@@ -11,12 +11,12 @@
             "elm/html": "1.0.0",
             "elm/http": "2.0.0",
             "elm/json": "1.1.2",
+            "elm/time": "1.0.0",
             "elm/url": "1.0.0"
         },
         "indirect": {
             "elm/bytes": "1.0.8",
             "elm/file": "1.0.5",
-            "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.2"
         }
     },


### PR DESCRIPTION
This is basically me feeling out the idea of using polling instead of
web sockets. It feels a bit weird. Going to keep playing around with it.

The intended behavior here is:

- On page load, load the latest game data, including the current
  spectator count
- While the game is active, refresh the game data every 5 seconds
- When the game is dormant, refresh the game data every 2 minutes

That means that when the game is dormant, the current spectator count
(and any other data we display in the future) will be up to two minutes
out of date. We can tune this a bit. I'm hoping to stay on the Heroku
free plan for the backend.