### PR TITLE
Display list of players on game page

### DIFF
--- a/api/app/models/dealer.rb
+++ b/api/app/models/dealer.rb
@@ -17,6 +17,7 @@ class Dealer
   #
   # - Can a player re-join after resigning?
   # - Should there be a ceiling on players?
+  # - Can a player join after the game has ended?
   def can_join?(human)
     current_players.exclude?(human)
   end
@@ -40,6 +41,11 @@ class Dealer
   # Later, will need to figure out how to make sure we count the pot
   def total_chips_count
     chip_counts.values.sum
+  end
+
+  # FIXME: record an action and use that to determine who the current dealer is
+  def player_with_dealer_chip
+    current_players&.first
   end
 
   private

--- a/api/app/views/games/_game_data.json.jbuilder
+++ b/api/app/views/games/_game_data.json.jbuilder
@@ -4,6 +4,7 @@ json.id game.identifier
 json.status game.status
 json.last_action_at Millis.new(game.last_action_at).to_i
 json.spectators_count game.recent_spectators_count
+json.current_dealer_id game.dealer.player_with_dealer_chip&.id
 json.players game.dealer.current_players,
              partial: 'players/player',
              as: :player,

--- a/api/app/views/games/_game_data.json.jbuilder
+++ b/api/app/views/games/_game_data.json.jbuilder
@@ -4,4 +4,8 @@ json.id game.identifier
 json.status game.status
 json.last_action_at Millis.new(game.last_action_at).to_i
 json.spectators_count game.recent_spectators_count
+json.players game.dealer.current_players,
+             partial: 'players/player',
+             as: :player,
+             locals: { dealer: game.dealer }
 json.total_chips_count game.dealer.total_chips_count

--- a/api/app/views/players/_player.json.jbuilder
+++ b/api/app/views/players/_player.json.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# deliberately _not_ sending uuid, which is strictly for authentication
+json.id player.id
+
+json.chips_count dealer.chip_count_for(player)

--- a/api/app/views/players/_player.json.jbuilder
+++ b/api/app/views/players/_player.json.jbuilder
@@ -2,5 +2,5 @@
 
 # deliberately _not_ sending uuid, which is strictly for authentication
 json.id player.id
-
+json.nickname player.nickname
 json.chips_count dealer.chip_count_for(player)

--- a/api/app/views/shared/_game.json.jbuilder
+++ b/api/app/views/shared/_game.json.jbuilder
@@ -7,6 +7,7 @@ end
 json.meta do
   if current_human.present?
     json.human do
+      json.id current_human.id
       json.nickname current_human.nickname
       json.heartbeat_at Millis.new(current_human.heartbeat_for(game)).to_i
       json.role game.dealer.role(current_human)

--- a/api/spec/controllers/profiles_controller_spec.rb
+++ b/api/spec/controllers/profiles_controller_spec.rb
@@ -27,9 +27,11 @@ RSpec.describe ProfilesController do
     context 'when the human already exists and has some games' do
       let(:game) { create_game }
       let(:human) { Human.recognize(uuid) }
+      let(:other_human) { create_human }
 
       before do
-        human.record_heartbeat(game)
+        GameAction::BuyIn.new(human, game).record
+        GameAction::BuyIn.new(other_human, game).record
       end
 
       it 'shows their games' do
@@ -42,9 +44,16 @@ RSpec.describe ProfilesController do
                    {
                      'id' => game.identifier,
                      'last_action_at' => Millis.new(game.last_action_at).to_i,
-                     'spectators_count' => 1,
+                     'players' => [{
+                       'id' => human.id,
+                       'chips_count' => 100
+                     }, {
+                       'id' => other_human.id,
+                       'chips_count' => 100
+                     }],
+                     'spectators_count' => 2,
                      'status' => 'pending',
-                     'total_chips_count' => 0
+                     'total_chips_count' => 200
                    }
                  ])
       end

--- a/api/spec/controllers/profiles_controller_spec.rb
+++ b/api/spec/controllers/profiles_controller_spec.rb
@@ -44,12 +44,15 @@ RSpec.describe ProfilesController do
                    {
                      'id' => game.identifier,
                      'last_action_at' => Millis.new(game.last_action_at).to_i,
+                     'current_dealer_id' => human.id,
                      'players' => [{
                        'id' => human.id,
-                       'chips_count' => 100
+                       'chips_count' => 100,
+                       'nickname' => human.nickname
                      }, {
                        'id' => other_human.id,
-                       'chips_count' => 100
+                       'chips_count' => 100,
+                       'nickname' => other_human.nickname
                      }],
                      'spectators_count' => 2,
                      'status' => 'pending',

--- a/api/spec/support/factories.rb
+++ b/api/spec/support/factories.rb
@@ -9,6 +9,7 @@ module Factories
 
   def create_human(attrs = {})
     Human.create!({
+      nickname: 'Joe MacMillan',
       uuid: SecureRandom.uuid
     }.merge(attrs))
   end

--- a/web/public/icons/arrow-right.svg
+++ b/web/public/icons/arrow-right.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" version="1.1" id="DESIGNS" x="0px" y="0px" width="32px" height="32px" viewBox="0 0 32 32" style="enable-background:new 0 0 32 32;" xml:space="preserve">
+<title property="dc:title">to go</title><desc property="dc:description">An icon for "go" from the Afiado series on to [icon]. Downloaded from http://www.toicon.com/icons/afiado_go by 24.193.122.233 on 2020-04-26. Licensed CC-BY, see http://toicon.com/license/ for details.</desc>
+<path class="afiado_een" d="M27.728,16.024l-8.485,8.482l-2.828-2.835L20.071,18H6v-4h14.071l-3.657-3.644l2.828-2.816  L27.728,16.024z" style="fill: #0B1719;"/>
+<metadata><work rdf:about=""><format>image/svg+xml</format><type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/><license rdf:resource="http://creativecommons.org/licenses/by/4.0/"/><attributionname>Susana Passinhas</attributionname><attributionurl>http://www.toicon.com/icons/afiado_go</attributionurl></work></metadata></svg>

--- a/web/src/Icon.elm
+++ b/web/src/Icon.elm
@@ -1,7 +1,12 @@
-module Icon exposing (closedEye, piggyBank)
+module Icon exposing (arrowRight, closedEye, piggyBank)
 
 import Html exposing (img)
-import Html.Attributes exposing (src)
+import Html.Attributes exposing (src, title)
+
+
+arrowRight : String -> Html.Html m
+arrowRight altText =
+    img [ src "/icons/arrow-right.svg", title altText ] []
 
 
 closedEye : Html.Html m

--- a/web/src/Main.elm
+++ b/web/src/Main.elm
@@ -867,7 +867,7 @@ view model =
                                                             [ p [] [ text "You're in!" ]
                                                             , p []
                                                                 [ Icon.piggyBank
-                                                                , text ("Chips on table: " ++ String.fromInt gameResponse.gameData.totalChipsCount ++ " chips")
+                                                                , text ("Chips on table: " ++ String.fromInt gameResponse.gameData.totalChipsCount)
                                                                 ]
                                                             ]
                                                 ]

--- a/web/src/main.css
+++ b/web/src/main.css
@@ -26,8 +26,34 @@ body {
   display: flex;
   flex: 1;
   justify-content: center;
-  justify-content: center;
   align-items: center;
+}
+
+.page-content.game-page {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-evenly;
+}
+
+.players-table {
+  /* background-color: orange; */
+  flex-grow: 3;
+}
+
+.game-actions {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 2;
+}
+
+.actions-list {
+  /* background-color: green; */
+  flex-grow: 1;
+}
+
+.action-buttons {
+  /* background-color: purple; */
+  flex-grow: 1;
 }
 
 input[type="submit"] {


### PR DESCRIPTION
This is WIP. so far I'm sending the data to the front end.

The next step will be to display that, and to add something like:

Add widget for displaying audit log of actions to all humans.

if players.count >= 2
  show "start game" button

when click "start game" button
  - transition game status to playing
  - pick a random player to be the dealer (emit action)
  - make the next two players put in their ante (emit actions)
  - make all the players draw a card (emit actions). Take care when
    displaying these actions to show the card to the right people.

Later:
  - Make the log group items by hand and collapse all but the most
    recent group

Unrelated, but I just realized I'm going to need to figure out how to
handle split pots. That'll be fun.