### PR TITLE
Update default branch name references

### DIFF
--- a/.github/workflows/elm-ci.yml
+++ b/.github/workflows/elm-ci.yml
@@ -2,9 +2,9 @@ name: Elm CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   test_elm:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,9 @@ name: Linters
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   lint:

--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -2,9 +2,9 @@ name: Ruby CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   test_ruby:

--- a/bin/deploy-api
+++ b/bin/deploy-api
@@ -4,7 +4,7 @@ set -ex
 
 echo "===> Deploying api"
 
-blob=`git subtree split --prefix api master`
+blob=`git subtree split --prefix api main`
 git push heroku "$blob":refs/heads/master --force
 
 echo "===> Done"

--- a/web/README.md
+++ b/web/README.md
@@ -17,7 +17,7 @@ PORT=3001 elm-app start
 ## Deploying
 
 The front-end auto-deploys to [Netlify](https://www.netlify.com/).
-They just notice when we push to master and they take care of it.
+They just notice when we push to the main branch and they take care of it.
 The build command and some other stuff are defined in the [netlify config file](../netlify.toml).
 
 ## Some links


### PR DESCRIPTION
We're joining the party on main street

Not sure if I can change the default branch for the heroku remote, so
I'm deferring that reference for now.